### PR TITLE
Add rule for linking social accounts with same email

### DIFF
--- a/rules/link-accounts-with-same-email.js
+++ b/rules/link-accounts-with-same-email.js
@@ -1,0 +1,68 @@
+// Rule links social accounts to base auth0 account
+
+function(user, context, callback) {
+  var request = require('request@2.56.0');
+
+  function _isBaseProfile(profile) {
+    return !!profile.identities.filter(function(i) {
+      return i.provider === 'auth0';
+    })[0];
+  }
+
+  if (_isBaseProfile(user)) {
+    return callback(null, user, context);
+  }
+
+  if (!user.email_verified) {
+    return callback(null, user, context);
+  }
+
+  var userSearchApiUrl = auth0.baseUrl + '/users-by-email';
+
+  request({
+    url: userSearchApiUrl,
+    headers: { Authorization: 'Bearer ' + auth0.accessToken },
+    qs: { email: user.email }
+  }, function(err, response, body) {
+    if (err) return callback(err);
+    if (response.statusCode !== 200) return callback(new Error(body));
+
+    var foundProfiles = JSON.parse(body);
+    var baseProfile = foundProfiles.filter(function(u) {
+      return u.email_verified && _isBaseProfile(u);
+    })[0];
+
+    if (!baseProfile) {
+      return callback(new UnauthorizedError('Auth0 profile was not found for ' + user.email));
+    }
+
+    var alreadyLinked = !!baseProfile.identities.filter(function(i) {
+      var userId = i.provider + '|' + i.user_id;
+      return userId === user.user_id;
+    })[0];
+
+    if (alreadyLinked) {
+      return callback(null, user, context);
+    }
+
+    var userApiUrl = auth0.baseUrl + '/users';
+    var provider = user.identities[0].provider;
+    var providerUserId = user.identities[0].user_id;
+
+    request.post({
+      url: userApiUrl + '/' + baseProfile.user_id + '/identities',
+      headers: { Authorization: 'Bearer ' + auth0.accessToken },
+      json: {
+        provider: provider,
+        user_id: providerUserId
+      }
+    }, function(err, response, body) {
+      if (response.statusCode >= 400) {
+        return callback(new Error('Error linking account: ' + response.statusMessage));
+      }
+
+      context.primaryUser = baseProfile.user_id;
+      callback(null, user, context);
+    });
+  });
+}

--- a/rules/link-accounts-with-same-email.json
+++ b/rules/link-accounts-with-same-email.json
@@ -1,0 +1,5 @@
+{
+  "enabled": false,
+  "order": 10,
+  "stage": "login_success"
+}


### PR DESCRIPTION
Trello https://trello.com/c/ES9F7Ttx/321-add-google-signin-option
Template for this rule is taken from https://github.com/auth0/rules/blob/master/rules/link-users-by-email.md
To finish this feature next steps is required
- Add connection to Google https://auth0.com/docs/connections/social/google
- Add Github deployment to Auth0 https://auth0.com/docs/extensions/github-deploy
- Enable rule in `rules/link-accounts-with-same-email.json` by setting `"enabled": true`